### PR TITLE
Adding install step (CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,13 @@ file(GLOB ReflexxesTypeII_SRC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     "src/*.cpp"
 )
 add_library(ReflexxesTypeII SHARED ${ReflexxesTypeII_SRC})
-target_include_directories(ReflexxesTypeII PUBLIC include/RMLTypeII)
+target_include_directories(ReflexxesTypeII
+  PUBLIC
+    $<INSTALL_INTERFACE:include/RMLTypeII>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/RMLTypeII>
+)
 
+add_library(RMLTypeII::ReflexxesTypeII ALIAS ReflexxesTypeII)
 
 if(BUILD_EXAMPLES)
   foreach(example IN ITEMS
@@ -43,3 +48,39 @@ if(BUILD_TESTS)
   add_executable(generator-csv test/generator-csv.cpp)
   target_link_libraries(generator-csv ReflexxesTypeII)
 endif()
+
+
+## Install
+include(GNUInstallDirs)
+set(INSTALL_CMAKE_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/RMLTypeII)
+
+install(TARGETS ReflexxesTypeII
+  EXPORT RMLTypeIITargets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY include/RMLTypeII DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+export(EXPORT RMLTypeIITargets
+  NAMESPACE RMLTypeII::
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/RMLTypeIITargets.cmake
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/RMLTypeIIConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(cmake/RMLTypeIIConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/RMLTypeIIConfig.cmake
+  INSTALL_DESTINATION ${INSTALL_CMAKE_CONFIG_DIR}
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/RMLTypeIIConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/RMLTypeIIConfigVersion.cmake
+  DESTINATION ${INSTALL_CMAKE_CONFIG_DIR}
+)
+install(EXPORT RMLTypeIITargets
+  NAMESPACE RMLTypeII::
+  DESTINATION ${INSTALL_CMAKE_CONFIG_DIR}
+)

--- a/cmake/RMLTypeIIConfig.cmake.in
+++ b/cmake/RMLTypeIIConfig.cmake.in
@@ -1,0 +1,8 @@
+get_filename_component(RMLTypeII_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+if(NOT TARGET RMLTypeII::ReflexxesTypeII)
+  include("${RMLTypeII_CMAKE_DIR}/RMLTypeIITargets.cmake")
+endif()


### PR DESCRIPTION
# Motivation

Currently, it is not possible to run a 'make install' because the install step is missing. 

# Changes
This PR adds the following
- Install step for  the headers and libraries
- Alias for the ReflexxesTypeII library